### PR TITLE
add Ruby version requirement

### DIFF
--- a/soracom.gemspec
+++ b/soracom.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '~> 2.0'
+
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
pi@raspberrypi ~ $ gem install soracom-1.0.3.gem
Building native extensions.  This could take a while...
ERROR:  Error installing soracom-1.0.3.gem:
soracom requires Ruby version ~> 2.0.
