### PR TITLE
SpeedClassのコマンドライン引数

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ soracom subscriber list | jq -r '.[].imsi' | tee imsi.txt
 
 複数のSIMに対して、プランを s1.fast に変更する
 ```
-$ soracom subscriber update_speed_class --imsi $(cat imsi.txt) --type s1.fast
+$ soracom subscriber update_speed_class --imsi $(cat imsi.txt) --speed-class s1.fast
 [
   {
     (変更後のSIMの情報)


### PR DESCRIPTION
現バージョンでは--speed-class が必須のようなので --typeを--speed-classに修正
