### PR TITLE
show API token for `$ soracom auth` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ testing authentication...
 authentication succeeded.
 apiKey: APIキー
 operatorId: OPで始まるオペレータID
+token: APIトークン
 ```
 
 #### 使用例

--- a/lib/soracom/cli.rb
+++ b/lib/soracom/cli.rb
@@ -278,6 +278,7 @@ module SoracomCli
 authentication succeeded.
 apiKey: #{client.api_key}
 operatorId: #{client.operator_id}
+token: #{client.token}
 EOS
       rescue => evar
         abort 'ERROR: ' + evar.to_s

--- a/lib/soracom/client.rb
+++ b/lib/soracom/client.rb
@@ -316,6 +316,11 @@ module Soracom
       @auth[:operatorId]
     end
 
+    # トークンを取得
+    def token
+      @auth[:token]
+    end
+
     private
 
     # authenticate by email and password


### PR DESCRIPTION
APIリクエスト時には基本的に token 情報もリクエストヘッダーに含めるかと思うのですが
`$ soracom auth` コマンドの出力結果には token が表示されていなかったので
表示させるようにしてみました。
