### PR TITLE
loosen LANG check

### DIFF
--- a/exe/soracom
+++ b/exe/soracom
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # coding: utf-8
 require 'soracom'
-if ENV['LANG'] =~ /[a-z][a-z]_[A-Z][A-Z]\.UTF-8$/
+if ENV['LANG'] =~ /[a-z][a-z]_[A-Z][A-Z]\.UTF-?8$/i
   SoracomCli::CLI.start
 else
   abort "LANG is not set properly to handle UTF-8. Currently set as #{ENV['LANG']}, but it should be xx_XX.UTF-8."


### PR DESCRIPTION
LANGチェックの基準を緩めました
- UTF-8 の “-“ がなくてもよい
- UTFが小文字でもよい

before:
$ LANG=ja_JP.utf8 soracom
LANG is not set properly to handle UTF-8. Currently set as ja_JP.utf8,
but it should be xx_XX.UTF-8.

after:
$ LANG=ja_JP.utf8 bundle exec exe/soracom
Commands:

soracom auth                     # test authentication
soracom complete                 # command list for shell completion
soracom event_handler <command>  # Event Handler related operations
soracom group <command>          # Group related operations
soracom help [COMMAND]           # Describe available commands or one
specif...
soracom sim <command>            # Subscriber related
operations(alias)
soracom stats <command>          # Stats related operations
soracom subscriber <command>     # Subscriber related operations
soracom support                  # open support site
soracom version                  # print version
