### PR TITLE
list_auth_keys のコマンドラインのヘルプを修正

### DIFF
--- a/lib/soracom/cli.rb
+++ b/lib/soracom/cli.rb
@@ -262,7 +262,7 @@ module SoracomCli
   end
 
   class Operator < Thor
-    desc 'create_auth_key', 'list auth keys'
+    desc 'list_auth_keys', 'list auth keys'
     def list_auth_keys
       client = Soracom::Client.new
       data = client.list_auth_keys()


### PR DESCRIPTION
soracom operator list_auth_keys のヘルプの表示が create_auth_key になってい
たので修正してみました。
