### PR TITLE
fix tag update

### DIFF
--- a/lib/soracom/client.rb
+++ b/lib/soracom/client.rb
@@ -155,7 +155,7 @@ module Soracom
       threads = [], result = []
       imsis.map do |imsi|
         threads << Thread.new do
-          result << { 'imsi' => imsi }.merge(@api.post(path: "/subscribers/#{imsi}/update_tags", payload: tags))
+          result << { 'imsi' => imsi }.merge(@api.put(path: "/subscribers/#{imsi}/tags", payload: tags))
         end
       end
       threads.each(&:join)


### PR DESCRIPTION
指定されたSubscriberのタグを追加・更新するAPIの呼び出しが行えなかった問題を修正
