### PR TITLE
remove io-console

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     soracom (1.1.5)
-      io-console
       thor
 
 GEM
@@ -10,7 +9,6 @@ GEM
   specs:
     coderay (1.1.0)
     diff-lcs (1.2.5)
-    io-console (0.4.2)
     method_source (0.8.2)
     pry (0.10.2)
       coderay (~> 1.1.0)
@@ -44,4 +42,4 @@ DEPENDENCIES
   soracom!
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/soracom.gemspec
+++ b/soracom.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
 
   spec.add_dependency 'thor'
-  spec.add_dependency 'io-console'
 end


### PR DESCRIPTION
io-console should not be in gemspec(its installed when ruby is installed)
otherwise it causes an error like below.

```
bundle exec rspec spec --format progress
bundler: failed to load command: rspec (/home/ubuntu/soracom/vendor/bundle/ruby/2.2.0/bin/rspec)
Gem::LoadError: You have already activated io-console 0.4.3, but your Gemfile requires io-console 0.4.2. Prepending `bundle exec` to your command may solve this.
  /opt/circleci/.rvm/gems/ruby-2.2.4/gems/bundler-1.12.5/lib/bundler/runtime.rb:35:in `block in setup'
  /opt/circleci/.rvm/gems/ruby-2.2.4/gems/bundler-1.12.5/lib/bundler/runtime.rb:20:in `map'
  /opt/circleci/.rvm/gems/ruby-2.2.4/gems/bundler-1.12.5/lib/bundler/runtime.rb:20:in `setup'
  /opt/circleci/.rvm/gems/ruby-2.2.4/gems/bundler-1.12.5/lib/bundler.rb:95:in `setup'
  /opt/circleci/.rvm/gems/ruby-2.2.4/gems/bundler-1.12.5/lib/bundler/setup.rb:9:in `<top (required)>'
  /opt/circleci/ruby/ruby-2.2.4/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
  /opt/circleci/ruby/ruby-2.2.4/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
```
