### PR TITLE
Support ruby version 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,5 +41,3 @@ DEPENDENCIES
   rspec
   soracom!
 
-BUNDLED WITH
-   1.14.6

--- a/soracom.gemspec
+++ b/soracom.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0'
 
-  spec.add_development_dependency 'bundler', '>= 2.0'
+  spec.add_development_dependency 'bundler', '>= 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'

--- a/soracom.gemspec
+++ b/soracom.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.9'
+  spec.add_development_dependency 'bundler', '>= 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'

--- a/soracom.gemspec
+++ b/soracom.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
# What
- ruby3系を利用してる場合、このGemをインストールするときに失敗した
- 原因は `soracom.gemspec` の通り、「ruby2.0.0 ~ 3.0.0未満」に固定しているため
- このPRで「ruby2.0.0以上」に修正します
- またbundlerが1.14.6に固定されてましたが、ruby3.0.0は2.2.3がdefault gemでエラーになるため、固定しないようにしました
    - ref: https://www.ruby-lang.org/ja/news/2020/12/25/ruby-3-0-0-released/

# Test
### 2系
```shell
# ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.arm64e-darwin20]
# Bundler version 1.17.2
soracom-sdk-ruby $ bundle install --path vendor/bundle
Using rake 10.4.2
Using bundler 1.17.2
Using coderay 1.1.0
Using diff-lcs 1.2.5
Using method_source 0.8.2
Using slop 3.6.0
Using pry 0.10.2
Using rspec-support 3.3.0
Using rspec-core 3.3.2
Using rspec-expectations 3.3.1
Using rspec-mocks 3.3.2
Using rspec 3.3.0
Using thor 0.19.4
Using soracom 1.1.9 from source at `.`
Bundle complete! 5 Gemfile dependencies, 14 gems now installed.
Bundled gems are installed into `./vendor/bundle`

soracom-sdk-ruby $ bundle exec rake build
soracom 1.1.9 built to pkg/soracom-1.1.9.gem.
```

### 3系
```shell
# ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [arm64-darwin20]
# Bundler version 2.2.3
soracom-sdk-ruby $ bundle install --path vendor/bundle
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor/bundle'`, and stop using this flag
Using rake 10.4.2
Using bundler 2.2.3
Using coderay 1.1.0
Using diff-lcs 1.2.5
Using method_source 0.8.2
Using slop 3.6.0
Using pry 0.10.2
Using rspec-support 3.3.0
Using rspec-core 3.3.2
Using rspec-expectations 3.3.1
Using rspec-mocks 3.3.2
Using rspec 3.3.0
Using thor 0.19.4
Using soracom 1.1.9 from source at `.`
Bundle complete! 5 Gemfile dependencies, 14 gems now installed.
Bundled gems are installed into `./vendor/bundle`

soracom-sdk-ruby $ bundle exec rake build
soracom 1.1.9 built to pkg/soracom-1.1.9.gem.
```