### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# About CODEOWNERS: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# These owners will be the default owners for everything in
+# the repo, unless a later match takes precedence.
+* moto@soracom.jp yuta@soracom.jp


### PR DESCRIPTION
Public リポジトリのブランチ保護ルールを作るために CODEOWNERS を設定します。