### PR TITLE
fix uncontrolled command line untrusted data directly to the shell

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in soracom.gemspec
 gemspec
+
+gem "launchy", "3.1.1"

--- a/lib/soracom/cli.rb
+++ b/lib/soracom/cli.rb
@@ -3,7 +3,7 @@
 require 'io/console'
 require 'thor'
 require 'open-uri'
-
+require 'launchy'
 module SoracomCli
   # SIM related commands
   class Subscriber < Thor
@@ -643,7 +643,11 @@ EOS
     def support
       client = Soracom::Client.new(profile:options.profile)
       url = client.get_support_url
-      system "open '#{url}' &> /dev/null || ( echo open following URL in your browser. ; echo '#{url}' )"
+      begin
+        Launchy.open(url)
+      rescue LoadError, StandardError
+        puts "Please open the following URL in your browser:\n#{url}"
+      end
     end
 
     desc 'version', 'print version'


### PR DESCRIPTION
https://github.com/soracom/soracom-sdk-ruby/blob/19491bdfa54ddbc9e83b9b83f25c4391c8fbf9d6/lib/soracom/cli.rb#L646-L646

Code that passes user input directly to `Kernel.system`, `Kernel.exec`, or some other library routine that executes a command, allows the user to execute malicious code.


fix this problem, we must avoid passing untrusted data directly to the shell. The best approach is to avoid using `system` with a string that is interpreted by the shell. Instead, use the array form of `system` to avoid shell interpretation, or better yet, use a library such as `Launchy` to open URLs in the user's browser in a safe, cross-platform way. If we must fall back to printing the URL, we should do so without invoking the shell.

**Detailed fix:**
- In `lib/soracom/cli.rb`, in the `support` method, replace the `system` call with a safe alternative.
- Use the `Launchy` gem to open the URL in the default browser, which does not invoke the shell with user input.
- If `Launchy` is not available, print the URL for the user to open manually.
- Add a `require 'launchy'` at the top of the file if not already present.

#### References
[Command Injection](https://www.owasp.org/index.php/Command_Injection)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)